### PR TITLE
Increase decentralization of the Ecosystem project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@monero-ecosystem/maintainers

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Be aware that when you transfer the repository, the founder of the Monero Ecosys
 # Governance system
 When a repo maintainer joins the ecosystem (s)he becomes part of our governance system, where all maintainers have equal power and decide how the project is structured and maintained. The governance system works as follow:
 
-+ The team who decide which proposals should be included and which not is composed by all repo maintainers inside the ecosystem. ErCiccione keeps a veto right as steward of the project (to be used only in extreme cases).
++ The team who decide which proposals should be included and which not is composed by all repo maintainers inside the ecosystem.
 + Proposals to add and remove a new repository should be posted on the *meta* repo using the issue tracker.
 + A repository will be accepted/removed when 50%+1 of the maintainers participating to the discussion reach consensus.
 + Substantial decisions about the Monero Ecosystem project shall be made using the same system as for the precedent point.


### PR DESCRIPTION
I think the Ecosystem is mature enough to be more decentralized. With this PR i propose to introduce some substantial changes, that will take of some powers from me and put it in the ends of the maintainers of this project:

- Remove my veto right in the voting process.
- Give maintainers "Write" powers to this repository (increased from "Triage")
- Add the maintainers group (who manage and develop the Ecosystem project) as codeowner of the project.

codeowners have push rights (which i already activated), which means they are able to merge pull requests and push on this repository. Along with this change, i introduced the requirement for all PRs to be reviewed by at least 1 maintaienr (codeowner) before it will be possible to merge. That to avoid people bypassing the review process by opening a PR and merging it without a review.

*This PR introduces substantial changes to the government of the project. I encourage the @monero-ecosystem/maintainers to review (approve) the PR to signal their approval*